### PR TITLE
Fixing copying a file across partitions

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -133,7 +133,7 @@ Job.prototype.finalize = function(code, tmpFile) {
   if (code == 0) {
     fs.rename(tmpFile, job.opts['destination_file'], function (err) {
       if (err) {
-        if (err.match(/EXDEV/)) {
+        if ( (err.message).match(/EXDEV/) ) {
           /*
             EXDEV fix, since util.pump is deprecated, using stream.pipe
             example from http://stackoverflow.com/questions/11293857/fastest-way-to-copy-file-in-node-js


### PR DESCRIPTION
Fixes #8
Using stream.pipe instead of util.pump, since the latter is deprecated
