### PR TITLE
fixed issue #39 related to database configuration.

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -49,6 +49,7 @@ var JobUtils = {
           dialect: config['database']['dialect'],
           storage: config['database']['database'],
           host: config['database']['host'],
+          port: config['database']['port'],
           logging: false
         });
       }


### PR DESCRIPTION
Add **port** with **config['database']['port']** inside Sequelize initialization inside getDatabase function in lib/jobs.js, so it can respect the port configuration.