### PR TITLE
* prevent transcoder of communicating negative free slot count

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,17 +3,18 @@ var os     = require('os'),
     fs     = require('fs'),
     logger = require('./logger');
 
-var config = {
-  port:                8080,
-  access_log:          '/var/log/access_log',
-  database:            { dialect: "sqlite", database: '/var/db/jobs.db' },
-  slots:               os.cpus().length,
-  interface:           "127.0.0.1",
-  encoder:             "ffmpeg",
-  scratch_dir:         "/tmp",
-  use_scratch_dir:     true,
-  ffprobe:             null 
-};
+var config =  {
+      port:                8080,
+      access_log:      	  "/var/local/codem-transcode/log/access.log",
+      database:            { dialect: "sqlite", database: '/var/local/codem-transcode/db/jobs.db' },
+      slots:               4,
+      interface:           "0.0.0.0",
+      encoder:             "ffmpeg",
+      scratch_dir:         "/var/local/codem-transcode/scratch/",
+      use_scratch_dir:     true,
+      ffprobe:             "ffprobe"
+    }
+    ;
 
 var loadedConfig = null;
 

--- a/lib/job-handler.js
+++ b/lib/job-handler.js
@@ -24,7 +24,9 @@ exports.find = function(id, callback) {
 }
 
 exports.freeSlots = function() {
-  return config['slots'] - slots.length;
+  var freeSlots = config['slots'] - slots.length;
+  if ( freeSlots < 0 ) return 0;
+  return freeSlots;
 }
 
 exports.cancelAndRemove = function(internalId, callback) {


### PR DESCRIPTION
Hi,

first of all: Ignore my changes in lib/config.js, as they are project specific and accidently pushed by me.

I am using the transcoder as a video-transcoding-solution in a 5 node cluster and it is working great so far. 
recently i found out, that the transcoder is able to communicate a negative slot count, which is interpreted wrong by codem-scheduler. this leads to sql query execution issues in codem-scheduler:/app/model/schedule.rb etc., because the parameter of LIMIT is negative. 
![tcode1](https://cloud.githubusercontent.com/assets/3886605/8512290/bc6d21de-2312-11e5-9611-bd6a0167d81e.png)

then codem-scheduler will start to overload the transcoding-client with jobs until the OS surrenders. 
so, i patched the freeSlots method in job-handler.js and thought maybe it is a good solution to share.

i like your work and i am a big fan of your company!
