### PR TITLE
sanitize null values before being put into SQL statement

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -50,7 +50,8 @@ var JobUtils = {
           storage: config['database']['database'],
           host: config['database']['host'],
           port: config['database']['port'],
-          logging: false
+          logging: false,
+          omitNull: true
         });
       }
     }


### PR DESCRIPTION
Set **Sequelize** ```omitNull=true``` to prevent null value passed into **sql insert statement**, because Sequelize explicitly set Jobs.id with null value so it will break database primary key validation.

Please see sequelize/sequelize#925 and [setup documentation](http://docs.sequelizejs.com/en/latest/api/sequelize)