### PR TITLE
Notifications - Use HTTPS when required

### DIFF
--- a/lib/notify-handler.js
+++ b/lib/notify-handler.js
@@ -1,5 +1,6 @@
 var url    = require('url'),
     http   = require('http'),
+    https   = require('https'),
     logger = require('./logger');
 
 exports.notify = function(job) {
@@ -23,7 +24,8 @@ exports.notify = function(job) {
                      'X-Codem-Notify-Timestamp': notificationTimestamp
                    }
         };
-        var req = http.request(urlOpts, function(res) {
+        var requestHandler = obj.protocol == "https:" ? https : http;
+        var req = requestHandler.request(urlOpts, function(res) {
           logger.log('Notification completed with HTTP status code: ' + res.statusCode);
         }).on('error', function(err) {
           logger.log("Failed delivering notification due to connection error: " + err);


### PR DESCRIPTION
Sometimes it is necessary to send notifications using HTTPS. This pull request provides support for it.