### PR TITLE
Move -ss to before -i

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -257,7 +257,12 @@ var Job = JobUtils.getDatabase().define('Job', {
           if (config['use_scratch_dir'] == true) {
             tmpFile = config['scratch_dir'] + path.sep + this.internalId + extension;
           }
-
+          var ssIndex = args.indexOf('-ss');
+          if (ssIndex > -1) {
+            var ssValueTemp = args[ssIndex + 1];
+            args.splice(ssIndex, 2);
+            Array.prototype.unshift.apply(args, ['-ss', ssValueTemp]);
+          }
           args.push(tmpFile);
 
           job.tmpFile = tmpFile;


### PR DESCRIPTION
moves the -ss option before the -i flag as per ffmpeg documentation.
“When used as an input option (before -i), seeks in this input file to
position.“