### PR TITLE
Upgrade sqlite3 package to 3.1.1 as 2.x is end of life.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "sequelize": "~1.6.0",
-    "sqlite3": "~2.2.0",
+    "sqlite3": "~3.1.1",
     "mkdirp": "~0.3.4",
     "express": "~2.5.11",
     "argsparser": "~0.0.6",


### PR DESCRIPTION
i tried to install codem transcoder today and it failed because sqlite3 says the version is end of lifecycle.
i then tried 2.6 latest 2.x and it failed as well. therefore i directly bumped it to the latest version 3.1.1 which works. 

node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/opt/codem-transcode/node_modules/sqlite3/node_modules/node-pre-gyp/lib/util/compile.js:76:29)
node-pre-gyp ERR! stack     at emitTwo (events.js:87:13)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:821:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
node-pre-gyp ERR! System Linux 4.2.0-30-generic
node-pre-gyp ERR! command "/usr/bin/nodejs" "/opt/codem-transcode/node_modules/sqlite3/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /opt/codem-transcode/node_modules/sqlite3
node-pre-gyp ERR! node -v v4.3.2
node-pre-gyp ERR! node-pre-gyp -v v0.5.19
node-pre-gyp ERR! not ok 
npm ERR! Linux 4.2.0-30-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install"
npm ERR! node v4.3.2
npm ERR! npm  v2.14.12
npm ERR! code ELIFECYCLE

npm ERR! sqlite3@2.2.4 install: `node-pre-gyp install --fallback-to-build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the sqlite3@2.2.4 install script 'node-pre-gyp install --fallback-to-build'.
npm ERR! This is most likely a problem with the sqlite3 package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-pre-gyp install --fallback-to-build
npm ERR! You can get their info via:
npm ERR!     npm owner ls sqlite3
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /opt/codem-transcode/npm-debug.log
stdout: 
