### PR TITLE
Increasing max buffer for ffmpeg processes to 8192

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -324,7 +324,7 @@ var Job = JobUtils.getDatabase().define('Job', {
                 '-segment_format', 'mpegts', '-segment_list', playlistPath,
                 '-segment_time', segmentTime, segmentsFormat);
 
-      child_process.execFile(config['encoder'], args, { maxBuffer: 4096*1024 }, function(error, stdout, stderr) {
+      child_process.execFile(config['encoder'], args, { maxBuffer: 8192*1024 }, function(error, stdout, stderr) {
         if (error) {
           job.lastMessage = 'Error while generating segments: ' + error.message;
           callbacks.error(job);


### PR DESCRIPTION
Apparently 4096 is not enough for some HLS segmenting variants. I've
explicitly left the thumb_process to 4096, this should still be more
than enough. As discussed in #59. 

NB: I've left changelog and version alone. Not sure whether this commit would suffice for a version bump. Thoughts?